### PR TITLE
勤怠編集の翌日チェックボックスは常にOFF

### DIFF
--- a/app/views/attendances/editing_one_month.html.erb
+++ b/app/views/attendances/editing_one_month.html.erb
@@ -48,9 +48,9 @@
                 <% end %>
               <% end %>
               <% if Date.current < day.worked_on %> <!-- 当日から判断して翌日以降は編集不可 -->
-                <td><%= attendance.check_box :next_day, {disabled: true}, true, nil %></td>
+                <td><%= attendance.check_box :next_day, {checked: false}, true, nil %></td>
               <% else %>
-                <td><%= attendance.check_box :next_day, {}, true, nil %></td>
+                <td><%= attendance.check_box :next_day, {checked: false}, true, nil %></td>
               <% end %>
                 <td>
                   <% if day.change_attendance_status&.approval? %>


### PR DESCRIPTION
勤怠編集で翌日チェックを入れて申請するとチェックが残ったままになる。
また残業申請で翌日チェック入れて申請した時も、勤怠編集にチェックが入ったままになるので、勤怠編集申請の時影響が出る